### PR TITLE
TF: Build with mpicc for mpi support

### DIFF
--- a/roles/tensorflow/defaults/main.yml
+++ b/roles/tensorflow/defaults/main.yml
@@ -38,6 +38,7 @@ tensorflow_dir_base: "{{ dir_home }}/tensorflow/{{ tensorflow_version}}"
 tensorflow_dir_src: "{{ tensorflow_dir_base }}/tensorflow-{{ tensorflow_version }}"
 tensorflow_configure: "{{ tensorflow_dir_src }}/configure"
 tensorflow_dir_output: "/tmp/tensorflow_pkg"
+build_tf_mpi: true
 tensorflow:
        release_url: "https://github.com/tensorflow/tensorflow/archive/v{{ tensorflow_version }}.zip"
        release_zip: "tensorflow-{{ tensorflow_version }}.zip"

--- a/roles/tensorflow/templates/configure_tensorflow.sh.j2
+++ b/roles/tensorflow/templates/configure_tensorflow.sh.j2
@@ -28,6 +28,7 @@
 
   # when using NCCL you need to install it own your own
   export GCC_HOST_COMPILER_PATH="{{ ohpc_toolchain_base_dir }}/bin/gcc"
+  export CC="{{ 'mpicc' if build_tf_mpi == true else '$GCC_HOST_COMPILER_PATH' }}"
   export HOST_C_COMPILER=$GCC_HOST_COMPILER_PATH
   export PREFIX="{{ ohpc_toolchain_base_dir }}"
   export CC_OPT_FLAGS="-march=native"


### PR DESCRIPTION
This commit adds a boolean, "build_tf_mpi" to toggle Tensorflow building with MPI support.
