### PR TITLE
Add role to build DNNL

### DIFF
--- a/build_tensorflow.yml
+++ b/build_tensorflow.yml
@@ -2,6 +2,7 @@
 - hosts: target
   roles:
           - common
+          - dnnl
           - openblas
           - bazel
           - numpy

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -109,6 +109,7 @@ LD_INCLUDE_PATH: "{{ hdf5_base_dir }}/include:{{ openblas_include_path }}:{{ mpi
 # Non OHPC, non python, non java
 tf_build_dependencies:
         - "@Development Tools"
+        - cmake
         - createrepo
         - rpm-build
         - vim

--- a/roles/dnnl/defaults/main.yml
+++ b/roles/dnnl/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# NumPy variables
+# See : https://github.com/ansible/ansible/issues/8603 
+# (No it's not "resolved", it's "bad design we can't fix")
+dnnl_version: "0.19"
+dnnl_prefix: "/opt/ohpc/pub/libs/gnu8/mkl-dnn"
+dnnl_dir_base: "{{ dir_home }}/dnnl/{{ dnnl_version}}"
+dnnl_dir_src: "{{ dnnl_dir_base }}/mkl-dnn-{{ dnnl_version }}"
+dnnl_dir_build: "{{ dnnl_dir_base }}/mkl-dnn-{{ dnnl_version }}/build"
+# https://github.com/intel/mkl-dnn/archive/v0.19.zip
+dnnl_dir_output: "{{ dnnl_prefix }}/"
+dnnl:
+       release_url: "https://github.com/intel/mkl-dnn/archive/v{{ dnnl_version }}.zip"
+       release_zip: "mkl-dnn-{{ dnnl_version }}.zip"
+       built_tarball: "dnnl_{{ dnnl_version }}_{{ build_id }}.tar.gz"
+       arch_opt_flags: ""
+       build_type: "DEBUG"

--- a/roles/dnnl/tasks/build_dnnl.yml
+++ b/roles/dnnl/tasks/build_dnnl.yml
@@ -1,0 +1,61 @@
+---
+- name: Delete build dirs dnnl
+  file:
+          path: "{{ item }}"       
+          state: absent
+  with_items:
+          - "{{ dnnl_dir_base }}"
+          - "{{ dnnl_dir_src }}"
+          - "{{ dnnl_dir_build }}"
+
+- name: Create build dirs dnnl
+  file:
+          path: "{{ item }}"       
+          state: directory
+          mode: '0755'
+          owner: "{{ user }}"
+          group: "{{ user }}"
+  with_items:
+          - "{{ dnnl_dir_base }}"
+          - "{{ dnnl_dir_src }}"
+          - "{{ dnnl_dir_build }}"
+
+- name: Create output dir
+  shell: "sudo rm -rf {{ dnnl_dir_output }} && sudo mkdir -p {{ dnnl_dir_output }}"  
+  args:
+          executable: "/bin/bash"
+
+- name: Fetch dnnl release tarball
+  get_url:
+          url: "{{ dnnl.release_url }}"
+          dest: "{{ dnnl_dir_base }}"
+
+- name: Unzip the release
+  unarchive:
+          src: "{{ dnnl_dir_base }}/{{ dnnl.release_zip }}"
+          remote_src: yes
+          dest: "{{ dnnl_dir_base }}"
+          extra_opts:
+            - -o
+  
+- name: Get the dnnl build scipt
+  template:
+          src: "build_dnnl.sh.j2"
+          dest: "{{ dnnl_dir_build }}/build_dnnl.sh"
+          mode: '0755'
+          owner: "{{ user }}"
+          group: "{{ user }}"
+
+- name: Build dnnl
+  shell: "./build_dnnl.sh"
+  args:
+          chdir: "{{ dnnl_dir_build }}"
+          executable: "/bin/bash"
+  register: dnnl_build_log
+- debug: var=dnnl_build_log
+
+- name: Tar-up dnnl output
+  archive:
+          path: "{{ dnnl_dir_output }}"
+          dest: "{{ dir_built }}/{{ dnnl.built_tarball }}"
+          format: gz

--- a/roles/dnnl/tasks/main.yml
+++ b/roles/dnnl/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Build DNNL
+  import_tasks: roles/dnnl/tasks/build_dnnl.yml
+  become: yes
+  become_user: "{{ user }}"
+  become_method: su
+  become_flags: "-s /bin/bash"

--- a/roles/dnnl/templates/build_dnnl.sh.j2
+++ b/roles/dnnl/templates/build_dnnl.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cmake -LA \
+      -DCMAKE_C_COMPILER:FILEPATH={{ ohpc_toolchain_base_dir }}/bin/gcc \
+      -DCMAKE_CXX_COMPILER:FILEPATH={{ ohpc_toolchain_base_dir }}/bin/g++ \
+      -DCMAKE_AR:FILEPATH={{ ohpc_toolchain_base_dir }}/bin/gcc-ar \
+      -DCMAKE_NM:FILEPATH={{ ohpc_toolchain_base_dir }}/bin/gcc-nm \
+      -DARCH_OPT_FLAGS:STRING={{ dnnl.arch_opt_flags | default('HostOpts') }} \
+      -DCMAKE_BUILD_TYPE:STRING={{ dnnl.build_type | default('DEBUG') }} \
+      .. 
+
+make -j
+sudo make install


### PR DESCRIPTION
This role adds the building of DNNL (or mkl-dnn in this version)
to the playbook.
DNNL will be used by TensorFlow to optimize via JIT the kernels
for the specific microarchitecture (and esp. for SVE).
Note that this commit does not hook the built DNNL to TensorFlow,
since it requires some Bazel build files investigation.