### PR TITLE
Hotfix: Test playbook leaked

### DIFF
--- a/build_tensorflow.yml
+++ b/build_tensorflow.yml
@@ -2,8 +2,8 @@
 - hosts: target
   roles:
           - common
-            #          - dnnl
-            #          - openblas
-            #          - bazel
+          - dnnl
+          - openblas
+          - bazel
           - numpy
           - tensorflow


### PR DESCRIPTION
Test playbook with roles commented out has been pushed accidentally,
this restores it as it should be.