### PR TITLE
Add Support for CentOS8 TF building & fixes

### DIFF
--- a/install_python3.yml
+++ b/install_python3.yml
@@ -5,6 +5,8 @@
             yum:
                     name: epel-release
                     state: latest
+            become: yes
+            become_method: sudo
 
           - name: Install Python3.6 from EPEL
             yum:
@@ -20,6 +22,8 @@
                             - libyaml-devel
                     state: latest
             when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 8
+            become: yes
+            become_method: sudo
 
           - name: Install Python3.6 from EPEL
             yum:
@@ -34,3 +38,5 @@
                     state: present
                     enablerepo: "PowerTools"
             when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8
+            become: yes
+            become_method: sudo

--- a/roles/bazel/tasks/main.yml
+++ b/roles/bazel/tasks/main.yml
@@ -10,3 +10,5 @@
 - name: Install Bazel (no build)
   import_tasks: roles/bazel/tasks/install_bazel.yml
   when: build_bazel == false
+  become: yes
+  become_method: sudo

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install dependencies
   import_tasks: roles/common/tasks/pre_build.yml
+  become: yes
+  become_method: sudo
 
 - name: Install python3 dependencies
   import_tasks: roles/common/tasks/pre_build_venv.yml

--- a/roles/numpy/defaults/main.yml
+++ b/roles/numpy/defaults/main.yml
@@ -6,11 +6,11 @@ numpy_version: "1.17.4"
 numpy_dir_base: "{{ dir_home }}/numpy/{{ numpy_version}}"
 numpy_dir_src: "{{ numpy_dir_base }}/numpy-{{ numpy_version }}"
 numpy_dir_output: "{{ numpy_dir_src }}/dist"
+numpy_patching_required: true
 numpy:
        release_url: "https://github.com/numpy/numpy/releases/download/v{{ numpy_version }}/numpy-{{ numpy_version }}.zip"
        release_zip: "numpy-{{ numpy_version }}.zip"
        release_sha256: "a0678793096205a4d784bd99f32803ba8100f639cf3b932dc63b21621390ea7e"
        wheel: "{{ numpy_dir_output }}/numpy-{{ numpy_version }}-cp36-cp36m-linux_aarch64.whl"
-       patching_required: true
        patch: 'numpy_centos7_aarch64.patch'
        built_tarball: "numpy_{{ numpy_version }}_{{ build_id }}.tar.gz"

--- a/roles/numpy/tasks/build_numpy.yml
+++ b/roles/numpy/tasks/build_numpy.yml
@@ -45,14 +45,14 @@
   template:
           src: "{{ numpy.patch }}.j2"
           dest: "{{ numpy_dir_src }}/{{ numpy.patch }}"
-  when: numpy.patching_required == true 
+  when: numpy_patching_required|bool == True
 
 - name: Apply patch
   shell: "patch -p0 -i {{ numpy_dir_src }}/{{ numpy.patch }}"
   args:
           chdir: "{{ numpy_dir_src }}"
           executable: "/bin/bash"
-  when: "{{ numpy.patching_required }}"
+  when: numpy_patching_required|bool == True
   
 - name: Build numpy
   shell: "source {{ venv_path }}/bin/activate && {{ numpy_dir_src }}/setup.py build bdist_wheel"

--- a/roles/numpy/templates/numpy_centos7_aarch64.patch.j2
+++ b/roles/numpy/templates/numpy_centos7_aarch64.patch.j2
@@ -10,7 +10,7 @@
  npy_cacosh@c@(@ctype@ z)
  {
      /*
-{% elif numpy_version in ['1.17.4'] %}
+{% elif numpy_version in ['1.17.4', '1.18.1'] %}
 --- numpy/core/src/npymath/npy_math_internal.h.src.orig	2019-11-14 12:20:01.387180922 +0000
 +++ numpy/core/src/npymath/npy_math_internal.h.src	2019-11-14 12:19:17.960646234 +0000
 @@ -477,7 +477,7 @@

--- a/roles/openblas/defaults/main.yml
+++ b/roles/openblas/defaults/main.yml
@@ -10,6 +10,7 @@ openblas_dir_src: "{{ openblas_dir_base }}/{{ openblas_version}}"
 openblas_dir_output: "{{ openblas_dir_src }}/output"
 openblas_target_micro: "ARMV8"
 openblas_additional_flags: ""
+openblas_pkgname: "openblas-{{ 'gnu8-ohpc-' if use_openhpc == true else '' }}{{ openblas_version }}"
 openblas:
        release_url: "https://github.com/xianyi/OpenBLAS/archive/develop.zip"
        release_zip: "openblas-develop.zip"

--- a/roles/openblas/tasks/build_openblas.yml
+++ b/roles/openblas/tasks/build_openblas.yml
@@ -48,7 +48,6 @@
           - "openblas-0.2.15-system_lapack.patch"
           - "openblas-0.2.5-libname.patch"
           - "openblas-0.2.15-constructor.patch"
-          - "openblas-0.3.3-noopt.patch"
   when: use_openhpc == false 
           
 - name: Fetch openblas release tarball

--- a/roles/openblas/tasks/install_openblas.yml
+++ b/roles/openblas/tasks/install_openblas.yml
@@ -12,5 +12,5 @@
 
 - name: Install openblas from the repo
   yum:
-          name: openblas-{{ openblas_version }}
+          name: "{{ openblas_pkgname }}" 
           state: present

--- a/roles/openblas/templates/openblas.repo.j2
+++ b/roles/openblas/templates/openblas.repo.j2
@@ -1,5 +1,5 @@
 [openblas_repo]
 name=OpenBLAS repo
-baseurl=file:///{{ dir_rpmbuilt }}
+baseurl=file://{{ dir_rpmbuilt }}
 enabled=1
 gpgcheck=0

--- a/roles/openblas/templates/openblas_upstream.spec.j2
+++ b/roles/openblas/templates/openblas_upstream.spec.j2
@@ -27,8 +27,6 @@ Patch0:         openblas-0.2.15-system_lapack.patch
 Patch1:         openblas-0.2.5-libname.patch
 # Don't use constructor priorities on too old architectures
 Patch2:         openblas-0.2.15-constructor.patch
-# Enable optimizations for all LAPACK sources
-Patch3:         openblas-0.3.3-noopt.patch
 
 BuildRequires:  gcc
 BuildRequires:  gcc-gfortran
@@ -228,7 +226,6 @@ cd OpenBLAS-develop
 %if 0%{?rhel} == 5
 %patch2 -p1 -b .constructor
 %endif
-%patch3 -p1 -b .noopt
 
 # Fix source permissions
 find -name \*.f -exec chmod 644 {} \;


### PR DESCRIPTION
This group of commits adds support for building on CentOS8, using a user benefiting from passwordless sudo.
It also adds NumPy 1.18.1 support (by applying the GCC bug workaround).